### PR TITLE
Sort assets alphabetically when writing manifest

### DIFF
--- a/lib/voog/dtk/filemanager.rb
+++ b/lib/voog/dtk/filemanager.rb
@@ -34,8 +34,10 @@ module Voog::Dtk
     end
 
     def write_manifest(manifest)
-      if manifest["layouts"].is_a?(Array)
-        manifest["layouts"].sort! { |a, b| a["file"] <=> b["file"]}
+      %w(assets layouts).each do |k|
+        if manifest[k].is_a?(Array)
+          manifest[k].sort! { |a, b| a["file"] <=> b["file"] }
+        end
       end
       File.open('manifest.json', 'w+', encoding: 'UTF-8') do |file|
         file << JSON.pretty_generate(manifest)


### PR DESCRIPTION
In addition to sorting the layouts of the `manifest.json` file alphabetically, sort the assets alphabetically as well.

Closes #57.